### PR TITLE
Import refactoring

### DIFF
--- a/ffq/exceptions.py
+++ b/ffq/exceptions.py
@@ -1,0 +1,26 @@
+"""Custom exception types used to raise specific errors"""
+
+
+class FfqException(Exception):
+    """Base FFQ Exception class to allow generic catches"""
+    pass
+
+
+class CliError(FfqException):
+    """Raised when the CLI is called with invalid arguments"""
+    pass
+
+
+class InvalidAccession(FfqException):
+    """Raised when an accession appears to be invalid"""
+    pass
+
+
+class ConnectionError(FfqException):
+    """Raised for any errors when fetching data"""
+    pass
+
+
+class BadData(FfqException):
+    """Raised when returned data does not look as expected"""
+    pass

--- a/ffq/ffq.py
+++ b/ffq/ffq.py
@@ -3,8 +3,8 @@ import logging
 import re
 import time
 from urllib.parse import urlparse
-import sys
 
+from ffq.exceptions import InvalidAccession
 from .utils import (
     geo_ids_to_gses, gsm_id_to_srs, get_doi, get_gse_search_json,
     get_gsm_search_json, get_xml, get_encode_json, get_samples_from_study,
@@ -317,8 +317,7 @@ def parse_gse_search(soup):
         geo_id = data['esearchresult']['idlist'][-1]
         return {'accession': accession, 'geo_id': geo_id}
     else:
-        logger.error("Provided GSE accession is invalid")
-        sys.exit(1)
+        raise InvalidAccession("Provided GSE accession is invalid")
 
 
 def parse_gse_summary(soup):

--- a/ffq/utils.py
+++ b/ffq/utils.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from frozendict import frozendict
 import logging
 
+from ffq.exceptions import InvalidAccession, ConnectionError, BadData
 from .config import (
     CROSSREF_URL, ENA_SEARCH_URL, ENA_URL, ENA_FETCH, GSE_SEARCH_URL,
     GSE_SUMMARY_URL, GSE_SEARCH_TERMS, GSE_SUMMARY_TERMS, NCBI_FETCH_URL,
@@ -39,19 +40,16 @@ def cached_get(*args, **kwargs):
     try:
         response.raise_for_status()
     except requests.HTTPError as exception:
-        if exception.getcode() == 429:
-            logger.error(
+        if hasattr(exception, 'getcode') and exception.getcode() == 429:
+            raise ConnectionError(
                 '429 Client Error: Too Many Requests. Please try again later'
             )
-            exit(1)
         else:
             logger.error(f'{exception}')
-            logger.error('Provided accession is invalid')
-            exit(1)
+            raise InvalidAccession('Provided accession is invalid')
     text = response.text
     if not text:
-        logger.warning(f'No metadata found in {args[0]}')
-        sys.exit(1)
+        raise BadData(f'No metadata found in {args[0]}')
     else:
         return response.text
 
@@ -116,8 +114,7 @@ def get_gsm_search_json(accession):
         geo_id = geo[-1]
         return {'accession': accession, 'geo_id': geo_id}
     else:
-        logger.error('Provided GSM accession is invalid')
-        sys.exit(1)
+        raise InvalidAccession('Provided GSM accession is invalid')
 
 
 def get_gse_summary_json(accession):
@@ -472,12 +469,10 @@ def ncbi_fetch_fasta(accession, db):
         response.raise_for_status()
     except requests.HTTPError as exception:
         logger.error(f'{exception}')
-        logger.error('Provided accession is invalid')
-        exit(1)
+        raise InvalidAccession('Provided accession is invalid')
     text = response.text
     if not text:
-        logger.warning(f'No metadata found for {accession}')
-        sys.exit(1)
+        raise BadData(f'No metadata found for {accession}')
     else:
         return BeautifulSoup(response.content, 'xml')
 
@@ -638,11 +633,10 @@ def gsm_id_to_srs(id):
                 logger.warning('No sample found')
                 return
     else:
-        logger.warning((
+        raise InvalidAccession((
             "No sample found. Either the provided GSM accession is "
             "invalid or raw data was not provided for this record"
         ))
-        exit(1)
     return sample
 
 
@@ -790,8 +784,7 @@ def gse_to_gsms(accession):
         gsms.sort()
         return gsms
     else:
-        logger.error("Provided GSE accession is invalid")
-        sys.exit(1)
+        raise InvalidAccession("Provided GSE accession is invalid")
 
 
 def gsm_to_srx(accession):
@@ -1033,8 +1026,7 @@ def parse_bioproject(soup):
     """
     # Exception for: the followin bioproject ID is not public
     if 'is not public in BioProject' in soup.text:
-        logger.error('The provided ID is not public in BioProject. Exiting')
-        sys.exit(0)
+        raise InvalidAccession('The provided ID is not public in BioProject.')
     target = soup.find('target')
     if target:
         target_material = target.get('material')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=read('requirements.txt').strip().split('\n'),
     entry_points={
-        'console_scripts': ['ffq=ffq.main:main'],
+        'console_scripts': ['ffq=ffq.main:cli'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Hi there!

Following on from thoughts in https://github.com/pachterlab/ffq/issues/22 we have been playing with the idea of wrapping `ffq` in a very simple wrapper to offer it as a REST API web service. If you're ok with the idea, we were thinking that we would be happy to host this at @SeqeraLabs as an open service for anyone to use.

I whipped up a quick proof of concept using [FastAPI](https://fastapi.tiangolo.com) in this repo: https://github.com/seqeralabs/ffq-api - it's running at https://ffq.seqera.io with [docs here](https://ffq.seqera.io/docs).

Thanks to the way that `ffq` is written, it was fantastically easy to do this (it's basically just [these lines](https://github.com/seqeralabs/ffq-api/blob/b80bb702091977e8a2e2273ea63e6046499f6611/src/ffq_api/app.py#L38-L63)). However, I did find that I needed to make a few minor upstream changes to `ffq` to get everything to play nicely:

- Moving the `argparse` CLI code into a separate function, so that the main call can be done without this
- Removing the `sys.exit(1)` calls which make sense for a command-line tool, but which kill an API service.

I did this by introducing some custom exception classes. It _should_ be functionally identical, but means that other tools making use of `ffq` as a library can capture and handle those exceptions however they need.

In addition to the API, these changes should also help people to use `ffq` in other situations, such as Jupyter Notebooks and inclusion into other Python tools.

On opening this PR I saw  that tests are failing - I think it's due to the NCBI issue you mention in the readme. If you'd like me to rebase / rewrite these changes against the `devel` branch instead then that's no problem. Equally if you'd prefer these changes done in a different way or not done at all then that's also fine 😀 Just thought it would be good to get the ball rolling..

Cheers, and many thanks again for a very useful tool 👏🏻 

Phil