### PR TITLE
Refactor for running as a library.

### DIFF
--- a/ffq/exceptions.py
+++ b/ffq/exceptions.py
@@ -1,0 +1,26 @@
+"""Custom exception types used to raise specific errors"""
+
+
+class FfqException(Exception):
+    """Base FFQ Exception class to allow generic catches"""
+    pass
+
+
+class CliError(FfqException):
+    """Raised when the CLI is called with invalid arguments"""
+    pass
+
+
+class InvalidAccession(FfqException):
+    """Raised when an accession appears to be invalid"""
+    pass
+
+
+class ConnectionError(FfqException):
+    """Raised for any errors when fetching data"""
+    pass
+
+
+class BadData(FfqException):
+    """Raised when returned data does not look as expected"""
+    pass

--- a/ffq/ffq.py
+++ b/ffq/ffq.py
@@ -3,8 +3,8 @@ import logging
 import re
 import time
 from urllib.parse import urlparse
-import sys
 
+from .exceptions import InvalidAccession
 from .utils import (
     geo_ids_to_gses, gsm_id_to_srs, get_doi, get_gse_search_json,
     get_gsm_search_json, get_xml, get_encode_json, get_samples_from_study,
@@ -317,8 +317,7 @@ def parse_gse_search(soup):
         geo_id = data['esearchresult']['idlist'][-1]
         return {'accession': accession, 'geo_id': geo_id}
     else:
-        logger.error("Provided GSE accession is invalid")
-        sys.exit(1)
+        raise InvalidAccession("Provided GSE accession is invalid")
 
 
 def parse_gse_summary(soup):

--- a/ffq/main.py
+++ b/ffq/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 
+from ffq.exceptions import CliError, InvalidAccession, FfqException
 from ffq.utils import findkey
 
 from . import __version__
@@ -55,7 +56,7 @@ FFQ.update({t: ffq_bioproject for t in BIOPROJECT_TYPES})
 FFQ.update({t: ffq_biosample for t in BIOSAMPLE_TYPES})
 
 
-def main():
+def cli():
     """Command-line entrypoint.
     """
     # Main parser
@@ -138,6 +139,15 @@ def main():
 
     args = parser.parse_args()
 
+    try:
+        print(json.dumps(run_ffq(args), indent=4))
+    except FfqException as e:
+        parser.error(e)
+
+
+def run_ffq(args):
+    """Main function to run ffq."""
+
     logging.basicConfig(
         format='[%(asctime)s] %(levelname)7s %(message)s',
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -150,16 +160,16 @@ def main():
 
     # Check the -o is provided if --split is set
     if args.split and not args.o:
-        parser.error('`-o` must be provided when using `--split`')
+        raise CliError('`-o` must be provided when using `--split`')
 
     if args.l:
         if ([args.ftp, args.ncbi, args.gcp, args.aws]).count(True) > 0:
-            parser.error("`-l` is not compatible with link fetching.")
+            raise CliError("`-l` is not compatible with link fetching.")
         if args.l <= 0:  # noqa
-            parser.error('level `-l` must greater than zero')
+            raise CliError('level `-l` must greater than zero')
     if args.t:
         if args.t not in SEARCH_TYPES:
-            parser.error(
+            raise CliError(
                 f"{args.t} is not a valide type. TYPES can be one of {', '.join(SEARCH_TYPES)}"
             )
 
@@ -169,19 +179,18 @@ def main():
     # check if accessions are valid (TODO separate cleaning accessions and checking them)
     for v in accessions:
         if v["prefix"] in ENCODE_TYPES and args.split:
-            parser.error(
+            raise CliError(
                 "`--split` is currently not compatible with ENCODE accessions"
             )
         if v["prefix"] in ENCODE_TYPES and ([args.ftp, args.aws, args.gcp,
                                              args.ncbi]).count(True) > 0:
-            parser.error(
+            raise CliError(
                 "Direct link fetching is currently not compatible with ENCODE accessions"
             )
         if v["valid"] is False:
-            parser.error(
+            raise InvalidAccession(
                 f"{v['accession']} is not a valid ID. IDs can be one of {', '.join(SEARCH_TYPES)}"  # noqa
             )
-            sys.exit(1)
 
     # we want to associate the args.x with the name of X
     # not just the true/false associated with args.x
@@ -234,6 +243,7 @@ def main():
             logger.exception(e)
         else:
             logger.error(e)
+            keyed["error_msg"] = str(e)
 
     if args.o:
         if args.split:
@@ -251,4 +261,4 @@ def main():
             with open(args.o, 'w') as f:
                 json.dump(keyed, f, indent=4)
     else:
-        print(json.dumps(keyed, indent=4))
+        return keyed

--- a/ffq/utils.py
+++ b/ffq/utils.py
@@ -43,7 +43,6 @@ def cached_get(*args, **kwargs):
             raise ConnectionError(
                 '429 Client Error: Too Many Requests. Please try again later'
             )
-            exit(1)
         else:
             logger.error(f'{exception}')
             raise InvalidAccession('Provided accession is invalid')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=read('requirements.txt').strip().split('\n'),
     entry_points={
-        'console_scripts': ['ffq=ffq.main:main'],
+        'console_scripts': ['ffq=ffq.main:cli'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Rewrite of pachterlab/ffq#29 against `devel`. Though I'd take it as a new PR as the merge conflict made it non-trivial to change the head branch.

See pachterlab/ffq#29 for more details, but in summary:

- Refactor CLI code to allow running without `argparse`
- Avoid using `sys.exit()`, introduce custom exception classes
