### PR TITLE
Fix --split

### DIFF
--- a/ffq/main.py
+++ b/ffq/main.py
@@ -254,12 +254,18 @@ def run_ffq(args):
     if args.o:
         if args.split:
             # Split each result into its own JSON.
+            outputfiles = []
             for result in keyed:
                 os.makedirs(args.o, exist_ok=True)
                 with open(
-                    os.path.join(args.o, f'{result["accession"]}.json'), "w"
+                    os.path.join(args.o, f'{result}.json'), "w"
                 ) as f:
-                    json.dump(result, f, indent=4)
+                    json.dump(keyed[result], f, indent=4)
+                    outputfiles.append(f.name)
+            
+            # Return a message that files were split (otherwise prints \null\)
+            return {"message": "Output was split into separate files", "files": outputfiles}
+            
         else:
             # Otherwise, write a single JSON with result accession as keys.
             if (

--- a/ffq/main.py
+++ b/ffq/main.py
@@ -263,8 +263,7 @@ def run_ffq(args):
                     json.dump(keyed[result], f, indent=4)
                     outputfiles.append(f.name)
             
-            # Return a message that files were split (otherwise prints \null\)
-            return {"message": "Output was split into separate files", "files": outputfiles}
+            sys.exit()
             
         else:
             # Otherwise, write a single JSON with result accession as keys.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     install_requires=read("requirements.txt").strip().split("\n"),
     entry_points={
-        "console_scripts": ["ffq=ffq.main:cli"],
+        "console_scripts": ["ffq=ffq.main:main"],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -47,3 +47,4 @@ class TestMixin(TestCase):
         cls.study_with_run_path = os.path.join(
             cls.fixtures_dir, "SRP096361_with_runlist.txt"
         )
+

--- a/tests/test_ffq.py
+++ b/tests/test_ffq.py
@@ -662,7 +662,7 @@ class TestFfq(TestMixin, TestCase):
         # test the functionality of --split ensuring the output file is created
         # and is a valid ffq json file
         import tempfile, json, os
-        tempdir = tempfile.mkdtemp(remove=True)
+        tempdir = tempfile.mkdtemp()
         with patch("sys.argv", ["main", "--split", "-o", tempdir, "SRR1581006"]):
             out = StringIO()
             sys.stdout = out
@@ -671,12 +671,13 @@ class TestFfq(TestMixin, TestCase):
             except SystemExit:
                 pass
             output = out.getvalue()
-            # parse json from output
-            output_json = json.loads(output)
-            self.assertEqual(output_json["message"], "Output was split into separate files")
-            self.assertEqual(len(output_json["files"]), 1)
+            
 
-            # load json from output file
+            # Test that the STDOUT is empty (an not "null")
+            self.assertEqual(output, "")
+       
+
+            # Test the output JSON file
             file_json = json.load(open(os.path.join(tempdir, "SRR1581006.json")))
             self.assertEqual(file_json["accession"], "SRR1581006")
 


### PR DESCRIPTION
As mentioned in issue #38, the main program when using --split is not saving separate records.
In this PR:
* entrypoint was named main() both in setup.py and ffq.py
* the behaviour of `--split` has been fixed. 
  * ~in addition (but can be removed) the split block returns a message (as JSON), otherwise, it would throw "null" to the user. In my use-case this can be a nice feedback but it's up to you if to keep this.~
* a functional test issues