### PR TITLE
Fix: Remove trailing slash from ENA URL in get_xml

### DIFF
--- a/ffq/utils.py
+++ b/ffq/utils.py
@@ -76,7 +76,7 @@ def get_xml(accession):
     :rtype: bs4.BeautifulSoup
     """
 
-    return BeautifulSoup(cached_get(f"{ENA_URL}/{accession}/"), "xml")
+    return BeautifulSoup(cached_get(f"{ENA_URL}/{accession}"), "xml")
 
 
 def get_encode_json(accession):


### PR DESCRIPTION
This PR addresses Issue #65, where samples were not being found for any GEO entries due to a malformed ENA URL. The root cause was identified as a trailing slash in the URL used within the `get_xml` function.

**Changes Made:**
- Removed the trailing slash from the ENA URL in the `get_xml` function of `ffq/utils.py`.
